### PR TITLE
Add terminal-based two-player tank artillery game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# tanx-game
+# Tanx - Text-Based Tank Duel
+
+Tanx is a minimalist two-player artillery duel played in the terminal. Two tanks
+face off on a procedurally generated, destructible landscape. Take turns to move,
+adjust your turret, and fire shells until your opponent reaches zero health.
+
+## Requirements
+
+* Python 3.9+
+
+## Running the Game
+
+```bash
+python main.py
+```
+
+The game starts immediately and prompts each player for commands on their turns.
+
+## Controls
+
+* `left` / `right` – drive the tank horizontally.
+* `up` / `down` – tilt the turret up or down.
+* `fire` – launch a shell at your opponent.
+* `status` – display tank information.
+* `help` – show the list of commands.
+* `quit` – exit the game early.
+
+Direct hits remove 25 hit points from the target tank. Near misses chip away at
+health and reshape the terrain. First tank to reach zero hit points loses.
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,12 @@
+"""Entry point for playing the Tanx artillery game."""
+
+from tanx_game.game import Game
+
+
+def main() -> None:
+    game = Game()
+    game.play()
+
+
+if __name__ == "__main__":
+    main()

--- a/tanx_game/__init__.py
+++ b/tanx_game/__init__.py
@@ -1,0 +1,5 @@
+"""Top-level package for the Tanx text-based tank battle game."""
+
+from .game import Game
+
+__all__ = ["Game"]

--- a/tanx_game/game.py
+++ b/tanx_game/game.py
@@ -1,0 +1,220 @@
+"""Interactive text-based game loop for Tanx."""
+
+from __future__ import annotations
+
+import math
+import os
+import time
+from dataclasses import dataclass
+from typing import List, Optional
+
+from .tank import Tank
+from .world import TerrainSettings, World
+
+
+@dataclass
+class ShotResult:
+    """Information about the projectile simulation."""
+
+    hit_tank: Optional[Tank]
+    impact_x: Optional[float]
+    impact_y: Optional[float]
+    path: List[tuple]
+
+
+class Game:
+    """Text-based artillery duel between two tanks."""
+
+    def __init__(
+        self,
+        player_one: str = "Player 1",
+        player_two: str = "Player 2",
+        settings: Optional[TerrainSettings] = None,
+        seed: Optional[int] = None,
+    ) -> None:
+        self.world = World(settings or TerrainSettings(seed=seed))
+        self.tanks = self._spawn_tanks(player_one, player_two)
+        self.gravity = 0.35
+        self.projectile_speed = 6.5
+        self.damage = 25
+        self.explosion_radius = 1.8
+
+    def _spawn_tanks(self, player_one: str, player_two: str) -> List[Tank]:
+        left_x, left_y = self._find_spawn(2, 1)
+        right_x, right_y = self._find_spawn(self.world.width - 3, -1)
+        return [
+            Tank(player_one, left_x, left_y, facing=1, turret_angle=45),
+            Tank(player_two, right_x, right_y, facing=-1, turret_angle=45),
+        ]
+
+    def _find_spawn(self, start: int, step: int) -> tuple[int, int]:
+        x = start
+        while 0 <= x < self.world.width:
+            surface = self.world.surface_y(x)
+            if surface is not None and surface >= 0:
+                return x, surface
+            x += step
+        raise RuntimeError("Failed to find spawn positions for tanks")
+
+    # Rendering -----------------------------------------------------------------
+    def render(self, projectile: Optional[tuple] = None) -> str:
+        grid = self.world.copy_grid()
+        for tank in self.tanks:
+            if tank.alive and 0 <= tank.y < self.world.height:
+                grid[tank.y][tank.x] = "T" if tank.facing > 0 else "t"
+        if projectile:
+            px, py = projectile
+            if 0 <= int(py) < self.world.height and 0 <= int(px) < self.world.width:
+                grid[int(py)][int(px)] = "*"
+        lines = ["".join(row) for row in grid]
+        return "\n".join(lines)
+
+    def info_panel(self) -> str:
+        return " | ".join(tank.info_line() for tank in self.tanks)
+
+    # Input ---------------------------------------------------------------------
+    def command_help(self) -> str:
+        return (
+            "Commands: left, right, up, down, fire, status, help, quit\n"
+            "  left/right: move the tank\n"
+            "  up/down: adjust turret angle\n"
+            "  fire: shoot a projectile\n"
+            "  status: display tank stats"
+        )
+
+    def parse_command(self, command: str) -> str:
+        return command.strip().lower()
+
+    # Simulation ----------------------------------------------------------------
+    def step_projectile(self, shooter: Tank) -> ShotResult:
+        angle_deg = shooter.turret_angle
+        direction = shooter.facing
+        angle_rad = math.radians(angle_deg)
+        vx = math.cos(angle_rad) * self.projectile_speed * direction
+        vy = -math.sin(angle_rad) * self.projectile_speed
+        x = shooter.x + 0.5 + direction * 0.6
+        y = shooter.y - 0.5
+        path: List[tuple] = []
+        hit_tank: Optional[Tank] = None
+        impact_x: Optional[float] = None
+        impact_y: Optional[float] = None
+        for _ in range(180):
+            x += vx
+            y += vy
+            vy += self.gravity
+            path.append((x, y))
+            if x < 0 or x >= self.world.width or y >= self.world.height:
+                break
+            if y < 0:
+                continue
+            ix = int(round(x))
+            iy = int(round(y))
+            for tank in self.tanks:
+                if not tank.alive or tank is shooter:
+                    continue
+                if abs(tank.x - x) <= 0.6 and abs(tank.y - y) <= 0.6:
+                    hit_tank = tank
+                    impact_x, impact_y = x, y
+                    break
+            if hit_tank:
+                break
+            if self.world.is_solid(ix, iy):
+                impact_x, impact_y = x, y
+                break
+        if impact_x is not None and impact_y is not None:
+            self.world.carve_circle(impact_x, impact_y, self.explosion_radius)
+        if hit_tank:
+            hit_tank.take_damage(self.damage)
+        elif impact_x is not None and impact_y is not None:
+            for tank in self.tanks:
+                if tank.alive and abs(tank.x - impact_x) <= 1.0 and abs(tank.y - impact_y) <= 1.0:
+                    tank.take_damage(self.damage // 2)
+        for tank in self.tanks:
+            if not tank.alive:
+                continue
+            self.settle_tank(tank)
+        return ShotResult(hit_tank, impact_x, impact_y, path)
+
+    # Game loop -----------------------------------------------------------------
+    def play(self) -> None:
+        os.system("clear")
+        print("Tanx - Text Artillery Duel")
+        print(self.command_help())
+        current = 0
+        while all(tank.alive for tank in self.tanks):
+            shooter = self.tanks[current]
+            print("\n" + self.render())
+            print(self.info_panel())
+            print(f"It's {shooter.name}'s turn. Last action: {shooter.last_command}")
+            command = self.parse_command(input("> "))
+            if command in {"quit", "exit"}:
+                print("Game aborted.")
+                return
+            if command in {"help", "?"}:
+                print(self.command_help())
+                continue
+            if command == "status":
+                print(self.info_panel())
+                continue
+            if command in {"left", "l"}:
+                if not shooter.move(self.world, -1):
+                    print("Cannot move left.")
+                else:
+                    current = 1 - current
+                continue
+            if command in {"right", "r"}:
+                if not shooter.move(self.world, 1):
+                    print("Cannot move right.")
+                else:
+                    current = 1 - current
+                continue
+            if command in {"up", "u"}:
+                shooter.raise_turret()
+                continue
+            if command in {"down", "d"}:
+                shooter.lower_turret()
+                continue
+            if command == "fire":
+                result = self.step_projectile(shooter)
+                self.animate_projectile(result)
+                current = 1 - current
+                continue
+            print("Unknown command. Type 'help' for a list of commands.")
+        winner = next(tank for tank in self.tanks if tank.alive)
+        loser = next(tank for tank in self.tanks if not tank.alive)
+        print("\n" + self.render())
+        print(self.info_panel())
+        print(f"{winner.name} wins! {loser.name} has been destroyed.")
+
+    def animate_projectile(self, result: ShotResult) -> None:
+        for position in result.path:
+            os.system("clear")
+            print("Tanx - Text Artillery Duel")
+            print(self.render(projectile=position))
+            print(self.info_panel())
+            time.sleep(0.05)
+        os.system("clear")
+        print("Tanx - Text Artillery Duel")
+        print(self.render())
+        print(self.info_panel())
+        if result.hit_tank:
+            print(f"Direct hit on {result.hit_tank.name}!")
+        elif result.impact_x is not None:
+            print("The shot impacted the terrain.")
+        else:
+            print("The shot flew off into the distance.")
+
+    def settle_tank(self, tank: Tank) -> None:
+        """Allow a tank to fall if the terrain beneath has been destroyed."""
+
+        while tank.y + 1 < self.world.height and not self.world.is_solid(
+            tank.x, tank.y + 1
+        ):
+            tank.y += 1
+        surface = self.world.surface_y(tank.x)
+        if surface is None:
+            return
+        if surface < 0:
+            tank.y = 0
+        elif surface < tank.y:
+            tank.y = surface

--- a/tanx_game/tank.py
+++ b/tanx_game/tank.py
@@ -1,0 +1,71 @@
+"""Tank entity definitions and actions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .world import World
+
+
+@dataclass
+class Tank:
+    """A player-controlled tank."""
+
+    name: str
+    x: int
+    y: int
+    facing: int  # 1 for right, -1 for left
+    hp: int = 100
+    turret_angle: int = 45
+    min_angle: int = -75
+    max_angle: int = 75
+    move_distance: int = 1
+    last_command: Optional[str] = field(default=None, init=False)
+
+    def clamp_turret(self) -> None:
+        self.turret_angle = max(self.min_angle, min(self.max_angle, self.turret_angle))
+
+    def raise_turret(self, amount: int = 5) -> None:
+        self.turret_angle += amount
+        self.clamp_turret()
+        self.last_command = f"turret +{amount}"
+
+    def lower_turret(self, amount: int = 5) -> None:
+        self.turret_angle -= amount
+        self.clamp_turret()
+        self.last_command = f"turret -{amount}"
+
+    def stand_y(self, world: World, x: int) -> Optional[int]:
+        surface = world.surface_y(x)
+        if surface is None:
+            return None
+        return surface
+
+    def move(self, world: World, direction: int) -> bool:
+        target_x = self.x + direction * self.move_distance
+        if not 0 <= target_x < world.width:
+            return False
+        surface = self.stand_y(world, target_x)
+        if surface is None or surface < 0:
+            return False
+        if abs(surface - self.y) > 1:
+            return False
+        self.x = target_x
+        self.y = surface
+        self.last_command = "left" if direction < 0 else "right"
+        return True
+
+    def take_damage(self, amount: int) -> None:
+        self.hp = max(0, self.hp - amount)
+
+    @property
+    def alive(self) -> bool:
+        return self.hp > 0
+
+    def info_line(self) -> str:
+        facing_arrow = ">" if self.facing > 0 else "<"
+        return (
+            f"{self.name} HP:{self.hp:3d} Pos:{self.x:2d}"
+            f" Angle:{self.turret_angle:3d}{facing_arrow}"
+        )

--- a/tanx_game/world.py
+++ b/tanx_game/world.py
@@ -1,0 +1,96 @@
+"""Procedural world generation and terrain handling for the Tanx game."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import random
+from typing import Iterable, List, Optional
+
+
+@dataclass
+class TerrainSettings:
+    """Configuration options for terrain generation."""
+
+    width: int = 48
+    height: int = 20
+    min_height: int = 4
+    max_height: int = 12
+    smoothing: int = 3
+    seed: Optional[int] = None
+
+
+class World:
+    """A simple 2D destructible terrain represented on a grid."""
+
+    def __init__(self, settings: Optional[TerrainSettings] = None) -> None:
+        self.settings = settings or TerrainSettings()
+        self.width = self.settings.width
+        self.height = self.settings.height
+        self.grid: List[List[bool]] = [
+            [False for _ in range(self.width)] for _ in range(self.height)
+        ]
+        self._generate()
+
+    def _generate(self) -> None:
+        rng = random.Random(self.settings.seed)
+        min_h = self.settings.min_height
+        max_h = self.settings.max_height
+        last_height = rng.randint(min_h, max_h)
+        column_heights: List[int] = []
+        for x in range(self.width):
+            delta = sum(rng.randint(-1, 1) for _ in range(self.settings.smoothing))
+            next_height = max(min_h, min(max_h, last_height + delta))
+            column_heights.append(next_height)
+            last_height = next_height
+        for x, column_height in enumerate(column_heights):
+            ground_start = self.height - column_height
+            for y in range(ground_start, self.height):
+                self.grid[y][x] = True
+
+    def is_inside(self, x: int, y: int) -> bool:
+        return 0 <= x < self.width and 0 <= y < self.height
+
+    def is_solid(self, x: int, y: int) -> bool:
+        if not self.is_inside(x, y):
+            return False
+        return self.grid[y][x]
+
+    def carve_circle(self, cx: float, cy: float, radius: float) -> None:
+        """Remove terrain in a circular radius around a point."""
+
+        r_sq = radius * radius
+        min_x = max(int(cx - radius) - 1, 0)
+        max_x = min(int(cx + radius) + 1, self.width - 1)
+        min_y = max(int(cy - radius) - 1, 0)
+        max_y = min(int(cy + radius) + 1, self.height - 1)
+        for y in range(min_y, max_y + 1):
+            for x in range(min_x, max_x + 1):
+                dx = x + 0.5 - cx
+                dy = y + 0.5 - cy
+                if dx * dx + dy * dy <= r_sq:
+                    self.grid[y][x] = False
+
+    def highest_solid(self, x: int) -> Optional[int]:
+        """Return the highest (smallest y) solid cell in the column."""
+
+        if not 0 <= x < self.width:
+            return None
+        for y in range(self.height):
+            if self.grid[y][x]:
+                return y
+        return None
+
+    def surface_y(self, x: int) -> Optional[int]:
+        """Return the y coordinate the tank should stand on for a column."""
+
+        top = self.highest_solid(x)
+        if top is None:
+            return None
+        return top - 1
+
+    def iter_rows(self) -> Iterable[str]:
+        for y in range(self.height):
+            yield "".join("#" if cell else " " for cell in self.grid[y])
+
+    def copy_grid(self) -> List[List[str]]:
+        return [["#" if cell else " " for cell in row] for row in self.grid]


### PR DESCRIPTION
## Summary
- implement a procedural destructible world, tank entities, and projectile simulation for a text-based duel
- add an entry-point script and package exports to launch the game
- document controls and usage instructions in the README

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e01f78708c832f8a3d5f02750941a0